### PR TITLE
fix remove createBrowserHistory Warning

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,6 @@
 import { createStore, applyMiddleware } from 'redux';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
-import createHistory from 'history/createBrowserHistory';
+import { createBrowserHistory as createHistory } from 'history';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import createSagaMiddleware from 'redux-saga';
 


### PR DESCRIPTION
fix for this warning:
Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. 
Support for the latter will be removed in the next major release.

